### PR TITLE
Add instructions for previewing the site in GitHub Codespaces and locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,4 @@ public/
 assets/jsconfig.json
 
 
-# notes
-how-to-deploy.md
-
 .DS_Store
-
-.github/

--- a/How-To-Preview.md
+++ b/How-To-Preview.md
@@ -1,0 +1,20 @@
+# Preview in GitHub Codespaces (recommended)
+1. Fork https://github.com/binchensun/fasr-website.  
+2. Go to codespaces (https://github.com/codespaces) and create a new Codespace from your fork .  
+3. Wait for the devcontainer to finish provisioning (it installs Hugo Extended and Go).  
+4. In the Codespaces terminal, run:
+   ```bash
+   hugo server -D
+   ```
+5. Open the forwarded URL to preview the site. If `hugo` is missing, rebuild the container or run `.devcontainer/setup.sh` once.
+6. Codespaces will pop up a forwarded port; click it to open the preview. Stop the server with `Ctrl+C` when done.
+
+# Preview Locally
+1. Clone your fork to your machine.  
+2. Install [Hugo Extended](https://gohugo.io/getting-started/installing/) (0.111.3+ recommended).  
+3. Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).  
+4. From the project root:
+   ```bash
+   hugo server -D
+   ```
+5. Visit http://localhost:1313 (hot reload on save). Drop `-D` to hide drafts. Stop with `Ctrl+C` when done.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ The **Frequency Agile Solar Radiotelescope (FASR)** is an advanced radio interfe
 
 For more information, visit [fasrtelescope.org](https://fasrtelescope.org/).
 
+## Previewing the Site
+
+You can preview the site either locally or using GitHub Codespaces. Instructions for both methods are provided in [How-to-Preview](How-To-Preview.md).
+
 ## Acknowledgements
 
 This website is built using the [Hugo](https://gohugo.io/) framework with the [Wowchemy Research Group](https://github.com/HugoBlox/theme-research-group) theme. You can fetch, contribute, compile, and deploy this repository.


### PR DESCRIPTION
Include detailed instructions for developers to preview the site both in GitHub Codespaces and on their local machines.